### PR TITLE
Support for continuous multi-line JSON objects

### DIFF
--- a/TimberWinR.ServiceHost/default.json
+++ b/TimberWinR.ServiceHost/default.json
@@ -26,17 +26,17 @@
                     "drop": "true"
                 }
             }
-        ]
-    },
-    "Outputs": {
-        "Redis": [
-            {
-                "_comment": "Change the host to your Redis instance",
-                "port": 6379,
-                "host": [
-                    "logaggregator.vistaprint.svc"
-                ]
-            }
-        ]
+        ],
+        "Outputs": {
+            "Redis": [
+                {
+                    "_comment": "Change the host to your Redis instance",
+                    "port": 6379,
+                    "host": [
+                        "logaggregator.vistaprint.svc"
+                    ]
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
CHG   TCP listeners now accepts continuous streams with multiline json snippets.
FIX   Default configuration template had Outputs on wrong (root) level, thus ignoring them.
